### PR TITLE
Relax type of returned values by DataLoader i…

### DIFF
--- a/src/data/dataloader.jl
+++ b/src/data/dataloader.jl
@@ -128,7 +128,7 @@ function DataLoader(f,
   fs = map(feat -> getindex(feat,
                  ntuple(i -> i == batchdim(feat) ? ix : Colon(), length(size(feat)))...), args)
   iterator = Iterators.partition(ix, batchsize)
-  ch = Channel{typeof(args)}(buffersize)
+  ch = Channel(buffersize)
   t = Task(() -> begin
     for i in iterator
       fullbatch = length(i) == batchsize


### PR DESCRIPTION
Relax type of returned values by DataLoader in case we want to onehot and pad per batch so it's not the same as input.